### PR TITLE
Non-lethal chestbursters

### DIFF
--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -264,7 +264,6 @@
 	user.visible_message("<span class='notice'>[icon2html(src, viewers(user))] \The [src] beeps: Defibrillation successful.</span>")
 	H.set_stat(UNCONSCIOUS)
 	H.emote("gasp")
-	H.chestburst = 0 //reset our chestburst state
 	H.regenerate_icons()
 	H.reload_fullscreens()
 	H.flash_act()

--- a/code/modules/arousal/organs/genital_datum.dm
+++ b/code/modules/arousal/organs/genital_datum.dm
@@ -211,6 +211,8 @@
 /mob/living/carbon/human/proc/give_genitals(clean = FALSE)//clean will remove all pre-existing genitals. proc will then give them any genitals that are enabled in their DNA
 	if(clean)
 		for(var/datum/internal_organ/genital/G in internal_organs)
+			internal_organs -= G
+			internal_organs_by_name -= G.name
 			qdel(G)
 
 	if(gender == MALE)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -29,7 +29,7 @@
 /mob/living/carbon/relaymove(mob/user, direction)
 	if(user.incapacitated(TRUE))
 		return
-	if(!chestburst && (status_flags & XENO_HOST) && isxenolarva(user))
+	if(!larva_birthing && (status_flags & XENO_HOST) && isxenolarva(user))
 		var/mob/living/carbon/xenomorph/larva/L = user
 		L.initiate_burst(src)
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -10,8 +10,6 @@
 			msg += "<span style='font-weight: bold; color: purple;'>You sense this creature is not organic.</span>\n"
 		if(status_flags & XENO_HOST)
 			msg += "This creature is impregnated and [reagents.get_reagent_amount(/datum/reagent/toxin/xeno_growthtoxin) > 0 ? "" : "not"] inoculated with Larval Accelerant. \n"
-		else if(chestburst == 2)
-			msg += "A larva escaped from this creature.\n"
 		if (headbitten)
 			msg += "This creature has been purged of vital organs in the head.\n"
 		if(istype(wear_mask, /obj/item/clothing/mask/facehugger))
@@ -455,9 +453,6 @@
 						msg += "<span class='warning'>[t_He] has blood pooling around [t_his] <b>left boot</b>!</span>\n"
 					if (display_foot_right)
 						msg += "<span class='warning'>[t_He] has blood pooling around [t_his] <b>right boot</b>!</span>\n"
-
-	if(chestburst == 2)
-		msg += "<span class='warning'><b>[t_He] has a giant hole in [t_his] chest!</b></span>\n"
 
 	if(headbitten)
 		msg += "<span class='warning'><b>[t_He] has a giant hole in [t_his] head!</b></span>\n"

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -687,17 +687,6 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	var/image/face_lying_image = new /image(icon = face_lying)
 	return face_lying_image
 
-/mob/living/carbon/human/update_burst()
-	remove_overlay(BURST_LAYER)
-	var/image/standing
-	if(chestburst == 1)
-		standing = image("icon" = 'icons/Xeno/Effects.dmi',"icon_state" = "burst_stand", "layer" =-BURST_LAYER)
-	else if(chestburst == 2)
-		standing = image("icon" = 'icons/Xeno/Effects.dmi',"icon_state" = "bursted_stand", "layer" =-BURST_LAYER)
-
-	overlays_standing[BURST_LAYER]	= standing
-	apply_overlay(BURST_LAYER)
-
 /mob/living/carbon/human/update_headbite()
 	remove_overlay(HEADBITE_LAYER)
 	var/image/standing

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -51,10 +51,6 @@
 		if(!silent)
 			to_chat(X, "<span class='warning'>This creature has already been headbitten.</span>")
 		return FALSE
-	if(victim.chestburst)
-		if(!silent)
-			to_chat(X, "<span class='warning'>This creature has already served its purpose.</span>")
-		return FALSE
 	if(X.issamexenohive(victim)) //checks if target and victim are in the same hive
 		if(!silent)
 			to_chat(X, "<span class='warning'>We can't bring ourselves to harm a fellow sister to this magnitude.</span>")
@@ -1015,7 +1011,7 @@
 		if(!ishuman(thing))
 			continue
 		var/mob/living/turf_mob = thing
-		if(turf_mob.stat == DEAD && turf_mob.chestburst == 0)
+		if(turf_mob.stat == DEAD)
 			valid_mobs += turf_mob
 
 	if(length(valid_mobs) < required_mobs)
@@ -1031,8 +1027,6 @@
 	for(var/mob/living/to_use AS in valid_mobs)
 		if(moved_human_number >= required_mobs)
 			break
-		to_use.chestburst = 2
-		to_use.update_burst()
 		to_use.forceMove(hivesilo)
 		moved_human_number++
 

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -115,7 +115,7 @@
 					affected_mob.jitter(105)
 					affected_mob.take_limb_damage(1)
 			if(prob(2))
-				to_chat(affected_mob, "<span class='warning'>[pick("Your chest hurts badly", "It becomes difficult to breathe", "Your heart starts beating rapidly, and each beat is painful")].</span>")
+				to_chat(affected_mob, "<span class='warning'>[pick("Your chest hurts badly", "It becomes difficult to breathe", "Your heart starts beating rapidly")].</span>")
 		if(5)
 			become_larva()
 		if(6)
@@ -160,19 +160,18 @@
 
 
 /mob/living/carbon/xenomorph/larva/proc/initiate_burst(mob/living/carbon/victim)
-	if(victim.chestburst || loc != victim)
+	if(victim.larva_birthing || loc != victim)
 		return
 
-	victim.chestburst = 1
-	ADD_TRAIT(victim, TRAIT_PSY_DRAINED, TRAIT_PSY_DRAINED)
-	to_chat(src, "<span class='danger'>We start bursting out of [victim]'s chest!</span>")
+	victim.larva_birthing = TRUE
+	to_chat(src, "<span class='danger'>We start slithering up [victim]'s throat!</span>")
 
-	victim.Unconscious(40 SECONDS)
 	victim.visible_message("<span class='danger'>\The [victim] starts shaking uncontrollably!</span>", \
-								"<span class='danger'>You feel something ripping up your insides!</span>")
+								"<span class='danger'>You feel something climbing up your throat!</span>")
+	victim.Unconscious(20 SECONDS)
 	victim.jitter(300)
 
-	victim.emote_burstscream()
+	playsound(victim, 'modular_skyrat/sound/weapons/gagging.ogg', 25, TRUE)
 
 	addtimer(CALLBACK(src, .proc/burst, victim), 3 SECONDS)
 
@@ -182,17 +181,15 @@
 		return
 
 	if(loc != victim)
-		victim.chestburst = 0
+		victim.larva_birthing = FALSE
 		return
-
-	victim.update_burst()
 
 	if(istype(victim.loc, /obj/vehicle/multitile/root))
 		var/obj/vehicle/multitile/root/V = victim.loc
 		V.handle_player_exit(src)
 	else
 		forceMove(get_turf(victim)) //moved to the turf directly so we don't get stuck inside a cryopod or another mob container.
-	playsound(src, pick('sound/voice/alien_chestburst.ogg','sound/voice/alien_chestburst2.ogg'), 25)
+	playsound(src, pick('sound/voice/alien_chestburst.ogg', 'sound/voice/alien_chestburst2.ogg'), 25)
 	GLOB.round_statistics.total_larva_burst++
 	SSblackbox.record_feedback("tally", "round_statistics", 1, "total_larva_burst")
 	var/obj/item/alien_embryo/AE = locate() in victim
@@ -202,32 +199,15 @@
 
 	if(ishuman(victim))
 		var/mob/living/carbon/human/H = victim
-		H.apply_damage(200, BRUTE, H.get_limb("chest"), updating_health = TRUE) //lethal armor ignoring brute damage
-		var/datum/internal_organ/O
-		for(var/i in list("heart", "lungs", "liver", "kidneys", "appendix")) //Bruise all torso internal organs
-			O = H.internal_organs_by_name[i]
+		H.adjustOxyLoss(50)
+		H.stuttering = 50
 
-			if(!H.mind && !H.client) //If we have no client or mind, permadeath time; remove the organs. Mainly for the NPC colonist bodies
-				H.internal_organs_by_name -= i
-				H.internal_organs -= O
-			else
-				O.take_damage(O.min_bruised_damage, TRUE)
-
-		var/datum/limb/chest = H.get_limb("chest")
-		var/datum/wound/internal_bleeding/I = new (15) //Apply internal bleeding to chest
-		chest.wounds += I
-		chest.fracture()
-
-
-	victim.chestburst = 2
-	victim.update_burst()
-	log_combat(src, null, "chestbursted as a larva.")
-	log_game("[key_name(src)] chestbursted as a larva at [AREACOORD(src)].")
+	victim.larva_birthing = FALSE
+	log_combat(src, null, "was born as a larva.")
+	log_game("[key_name(src)] was born as a larva at [AREACOORD(src)].")
 
 	if((locate(/obj/structure/bed/nest) in loc) && hive.living_xeno_queen?.z == loc.z)
 		burrow()
-
-	victim.death()
 
 
 /mob/living/proc/emote_burstscream()

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -72,7 +72,7 @@
 	var/on_fire //The "Are we on fire?" var
 	var/fire_stacks = 0 //Tracks how many stacks of fire we have on, max is
 
-	var/chestburst = 0 // 0: normal, 1: bursting, 2: bursted.
+	var/larva_birthing = FALSE
 	var/headbitten = FALSE //false: normal, true: brain removed
 	var/metabolism_efficiency = 1 //more or less efficiency to metabolize helpful/harmful reagents and (TODO) regulate body temperature..
 

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -348,7 +348,7 @@
 	REMOVE_TRAIT(src, TRAIT_UNDEFIBBABLE, TRAIT_UNDEFIBBABLE)
 	REMOVE_TRAIT(src, TRAIT_PSY_DRAINED, TRAIT_PSY_DRAINED)
 	dead_ticks = 0
-	chestburst = 0
+	larva_birthing = FALSE
 	headbitten = FALSE
 	update_body()
 	update_hair()

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -27,6 +27,9 @@
 		return 0
 
 /datum/internal_organ/Destroy()
+	var/datum/limb/L = owner.get_limb(parent_limb)
+	if(L)
+		L.internal_organs -= src
 	owner.internal_organs -= src
 	owner.internal_organs_by_name -= name
 	owner = null

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -193,10 +193,6 @@
 		to_chat(user, "<span class='notice'>[victim] is not dead!</span>")
 		return
 
-	if(victim.chestburst)
-		to_chat(user, "<span class='notice'>[victim] has already been exhausted to incubate a sister!</span>")
-		return
-
 	if(issynth(victim))
 		to_chat(user, "<span class='notice'>[victim] has no useful biomass for us.</span>")
 		return
@@ -206,8 +202,6 @@
 	if(!do_after(user, 20, FALSE, victim, BUSY_ICON_DANGER) || QDELETED(src))
 		return
 
-	victim.chestburst = 2 //So you can't reuse corpses if the silo is destroyed
-	victim.update_burst()
 	victim.forceMove(src)
 
 	shake(4 SECONDS)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Made chestbursters non-lethal.
Rather than violently tearing out of the host's chest, the larva now climbs up their throat instead, causing some oxyloss and stuttering.
Once the larva is born, the host is immediately ready for another! (This isn't at all abusable)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Being caught by a xenomorph on this server is something of a death sentence currently, which kinda defeats the point.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Chestbursters no longer burst chests, and instead non-lethally escape up the host's throat.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
