### PR TITLE
End round vote + xeno spawns

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -218,6 +218,16 @@ Voting
 	integer = TRUE
 	min_val = 0
 
+/datum/config_entry/number/vote_autotransfer_initial
+	config_entry_value = 72000
+	integer = FALSE
+	min_val = 0
+
+/datum/config_entry/number/vote_autotransfer_interval
+	config_entry_value = 18000
+	integer = FALSE
+	min_val = 0
+
 /*
 Master controller and performance related.
 */

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -23,6 +23,7 @@ SUBSYSTEM_DEF(ticker)
 
 	var/time_left							//Pre-game timer
 	var/start_at
+	var/next_autotransfer = 0 // End of round vote timer
 
 	var/roundend_check_paused = FALSE
 
@@ -102,6 +103,10 @@ SUBSYSTEM_DEF(ticker)
 			mode.process(wait * 0.1)
 			check_queue()
 
+			if(world.time > next_autotransfer)
+				SSvote.autotransfer()
+				next_autotransfer = world.time + CONFIG_GET(number/vote_autotransfer_interval)
+
 			if(!roundend_check_paused && mode.check_finished(force_ending) || force_ending)
 				current_state = GAME_STATE_FINISHED
 				GLOB.ooc_allowed = TRUE
@@ -160,6 +165,9 @@ SUBSYSTEM_DEF(ticker)
 
 	current_state = GAME_STATE_PLAYING
 	Master.SetRunLevel(RUNLEVEL_GAME)
+
+	// Sets the auto transfer vote to happen after the config duration
+	next_autotransfer = world.time + CONFIG_GET(number/vote_autotransfer_initial)
 
 	CHECK_TICK
 	PostSetup()

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -37,6 +37,9 @@ SUBSYSTEM_DEF(vote)
 		SStgui.close_uis(src)
 		reset()
 
+/datum/controller/subsystem/vote/proc/autotransfer()
+	initiate_vote("restart", "the server")
+
 /// Stop the current vote and reset everything
 /datum/controller/subsystem/vote/proc/reset()
 	choices.Cut()
@@ -197,6 +200,7 @@ SUBSYSTEM_DEF(vote)
 		reset()
 		switch(vote_type)
 			if("restart")
+				question = "End the round?"
 				choices.Add("Restart Round", "Continue Playing")
 			if("gamemode")
 				for(var/datum/game_mode/mode AS in config.votable_modes)

--- a/code/datums/gamemodes/extended.dm
+++ b/code/datums/gamemodes/extended.dm
@@ -1,6 +1,8 @@
 /datum/game_mode/extended
 	name = "Extended"
 	config_tag = "Extended"
+	flags_round_type = MODE_XENO_RULER
+	flags_landmarks = MODE_LANDMARK_SPAWN_XENO_TUNNELS|MODE_LANDMARK_SPAWN_MAP_ITEM
 	flags_xeno_abilities = ABILITY_DISTRESS
 
 	valid_job_types = list(
@@ -21,7 +23,9 @@
 		/datum/job/terragov/squad/corpsman = 8,
 		/datum/job/terragov/squad/smartgunner = 4,
 		/datum/job/terragov/squad/leader = 4,
-		/datum/job/terragov/squad/standard = -1
+		/datum/job/terragov/squad/standard = -1,
+		/datum/job/xenomorph = 2,
+		/datum/job/xenomorph/queen = 1
 	)
 
 /datum/game_mode/extended/announce()

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -5,7 +5,7 @@
 	var/mob/living/carbon/xenomorph/living_xeno_ruler
 	var/slashing_allowed = XENO_SLASHING_ALLOWED //This initial var allows the queen to turn on or off slashing. Slashing off means harm intent does much less damage.
 	var/xeno_queen_timer
-	var/xenos_per_queen = 8 //Minimum number of xenos to support a queen.
+	var/xenos_per_queen = 4 //Minimum number of xenos to support a queen.
 	var/hive_orders = "" //What orders should the hive have
 	var/color = null
 	var/prefix = ""

--- a/config/config.txt
+++ b/config/config.txt
@@ -197,6 +197,12 @@ CHECK_RANDOMIZER
 ##Set this number to the maximum number of players you want, after which game mode votes cannot be started
 MAXIMUM_CLIENTS_FOR_GAMEMODE_VOTE 40
 
+## autovote initial delay (deciseconds) before first automatic transfer vote call (default 60 minutes)
+VOTE_AUTOTRANSFER_INITIAL 18000
+
+##autovote delay (deciseconds) before sequential automatic transfer votes are called (default 60 minutes)
+VOTE_AUTOTRANSFER_INTERVAL 18000
+
 ## Uncomment these to set a custom respawn timer; the delay is in ticks.
 #MARINE_RESPAWN 18000
 #XENO_RESPAWN 1200


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds an auto-restart vote system, with each vote happening at 1H intervals until the round is ended.
Also (hopefully) adds xeno spawns and roundstart tunnels to the extended gamemode. (Needs playtesting really)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
A way to actually end the round early if people want it, and xeno spawns.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added a 1H 'Restart round' vote.
add: (Hopefully) added xeno spawns to extended.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
