### PR TITLE
A few QOL tweaks

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -149,13 +149,16 @@ SUBSYSTEM_DEF(vote)
 			if(!C.is_afk() && check_rights_for(C, R_SERVER))
 				active_admins = TRUE
 				break
-		if(!active_admins)
-			// No delay in case the restart is due to lag
-			SSticker.Reboot("Restart vote successful.", "restart vote", 1)
-		else
-			to_chat(world, "<span style='boltnotice'>Notice:Restart vote will not restart the server automatically because there are active admins on.</span>")
-			message_admins("A restart vote has passed, but there are active admins on with +SERVER, so it has been canceled. If you wish, you may restart the server.")
 
+		if(!active_admins) // No admins
+			// No delay in case the restart is due to lag
+			SSticker.Reboot("Restart vote successful.", 5 SECONDS)
+
+		else if(admin_approval("Restart the round?", admin_sound = 'sound/effects/adminhelp.ogg'))
+			SSticker.Reboot("Restart vote successful.", 5 SECONDS) // Admins online, and they approve
+
+		else // Admins disapprove
+			to_chat(world, "<span style='boldnotice'>Reboot was cancelled by an admin.</span>")
 
 
 /// Register the vote of one player

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -48,7 +48,7 @@
 	if(params && message_param)
 		msg = select_param(user, params)
 
-	msg = replace_pronoun(user, msg)
+	//msg = replace_pronoun(user, msg) // why is this a thing
 
 	if(!msg)
 		return

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -191,8 +191,11 @@
 	if(holder?.fakekey)
 		display_name = holder.fakekey
 
-	for(var/I in GLOB.xeno_mob_list)
-		to_chat(I, "<font color='red'><b>XOOC:</b> <i>[display_name]:</i> [msg]</font>")
+	for(var/mob/M in GLOB.player_list)
+		if(check_other_rights(M.client, R_ADMIN, FALSE))
+			to_chat(M, "<span class='event_announcement'>Xeno OOC: [key_name_admin(key)]: [msg]</span>")
+		else if(istype(M, /mob/living/carbon/xenomorph) || istype(M, /mob/dead/observer))
+			to_chat(M, "<span class='event_announcement'>Xeno OOC: [display_name]: [msg]</span>")
 
 	mob.log_talk(msg, LOG_XOOC)
 
@@ -212,8 +215,11 @@
 	if(holder?.fakekey)
 		display_name = holder.fakekey
 
-	for(var/I in GLOB.human_mob_list)
-		to_chat(I, "<font color='red'><b>MOOC:</b> <i>[display_name]:</i> [msg]</font>")
+	for(var/mob/M in GLOB.player_list)
+		if(check_other_rights(M.client, R_ADMIN, FALSE))
+			to_chat(M, "<span class='event_announcement'>Marine OOC: [key_name_admin(key)]: [msg]</span>")
+		else if(istype(M, /mob/living/carbon/human) || istype(M, /mob/dead/observer))
+			to_chat(M, "<span class='event_announcement'>Marine OOC: [display_name]: [msg]</span>")
 
 	mob.log_talk(msg, LOG_MOOC)
 

--- a/code/modules/admin/holder.dm
+++ b/code/modules/admin/holder.dm
@@ -303,7 +303,9 @@ GLOBAL_PROTECT(admin_verbs_default)
 	/client/proc/private_message_panel,
 	/client/proc/private_message_context,
 	/client/proc/msay,
-	/client/proc/dsay
+	/client/proc/dsay,
+	/client/proc/marine_ooc,
+	/client/proc/xeno_ooc
 	)
 GLOBAL_LIST_INIT(admin_verbs_admin, world.AVadmin())
 GLOBAL_PROTECT(admin_verbs_admin)

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1351,7 +1351,6 @@
 	use_state_flags = XACT_USE_STAGGERED|XACT_USE_FORTIFIED|XACT_USE_CRESTED //can't use while staggered, defender fortified or crest down
 	keybind_signal = COMSIG_XENOABILITY_REGURGITATE
 	plasma_cost = 100
-	gamemode_flags = ABILITY_HUNT
 
 /datum/action/xeno_action/activable/devour/can_use_ability(atom/A, silent, override_flags)
 	. = ..()
@@ -1359,7 +1358,8 @@
 		return
 	var/mob/living/carbon/xenomorph/X = owner
 	if(LAZYLEN(X.stomach_contents)) //Only one thing in the stomach at a time, please
-		succeed_activate()
+		to_chat(owner, "<span class='warning'>Our stomach is already full!</span>")
+		return FALSE
 	if(!ishuman(A) || issynth(A))
 		to_chat(owner, "<span class='warning'>That wouldn't taste very good.</span>")
 		return FALSE
@@ -1368,10 +1368,10 @@
 		return FALSE
 	if(!owner.Adjacent(victim)) //checks if owner next to target
 		return FALSE
-	if(victim.stat != DEAD)
-		if(!silent)
-			to_chat(owner, "<span class='warning'>This creature is struggling too much for us to devour it.</span>")
-		return FALSE
+	//if(victim.stat != DEAD)
+	//	if(!silent)
+	//		to_chat(owner, "<span class='warning'>This creature is struggling too much for us to devour it.</span>")
+	//	return FALSE
 	if(victim.buckled)
 		if(!silent)
 			to_chat(owner, "<span class='warning'>[victim] is buckled to something.</span>")

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -951,6 +951,24 @@
 	log_directed_talk(X, L, msg, LOG_SAY, "psychic whisper")
 	to_chat(L, "<span class='alien'>You hear a strange, alien voice in your head. <i>\"[msg]\"</i></span>")
 	to_chat(X, "<span class='xenonotice'>We said: \"[msg]\" to [L]</span>")
+	for(var/_M in GLOB.player_list) // it's the xeno's main method of communication, so it should be visible
+		var/mob/M = _M
+		if(M == L || M == X)
+			continue
+		if(M.stat != DEAD) //not dead, not important
+			continue
+		if(!M.client)
+			continue
+		if(get_dist(M, X) > 7 || M.z != X.z) //they're out of range of normal hearing
+			if(!(M.client.prefs.toggles_chat & CHAT_GHOSTEARS))
+				continue
+		if((istype(M.remote_control, /mob/camera/aiEye) || isAI(M))) // Not sure why this is here really, but better safe than sorry
+			continue
+
+		if(check_other_rights(M.client, R_ADMIN, FALSE))
+			to_chat(M, "<span class='alien'>Psychic Whisper: <b>[ADMIN_LOOKUP(X)] > [ADMIN_LOOKUP(L)]:</b> <i>\"[msg]\"</i></span>")
+		else
+			to_chat(M, "<span class='alien'>Psychic Whisper: <b>[X] > [L]:</b> <i>\"[msg]\"</i></span>")
 
 
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -240,7 +240,8 @@
 	return ..()
 
 /mob/living/carbon/xenomorph/pull_response(mob/puller)
-	if(stat != CONSCIOUS) // If the Xeno is unconscious, don't fight back against a grab/pull
+	return TRUE
+	/*if(stat != CONSCIOUS) // If the Xeno is unconscious, don't fight back against a grab/pull
 		return TRUE
 	if(!ishuman(puller))
 		return TRUE
@@ -249,7 +250,7 @@
 	playsound(H.loc, 'sound/weapons/pierce.ogg', 25, 1)
 	H.visible_message("<span class='warning'>[H] tried to pull [src] but instead gets a tail swipe to the head!</span>")
 	H.stop_pulling()
-	return FALSE
+	return FALSE*/
 
 /mob/living/carbon/xenomorph/resist_grab()
 	if(pulledby.grab_state)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -15,7 +15,7 @@
 	if(!message)
 		return
 
-	message = trim(copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN))
+	message = sanitize(message)
 
 	emote("me", EMOTE_VISIBLE, message, TRUE)
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
1. Gives admins access to the XOOC and MOOC channels, since I apparently forgot to do that in #17.
2. Made round-end restart votes which pass default to actually restart unless an admin cancels it, rather than the other way around.
3. Made xenomorphs always pullable by humans.
4. Allowed ghosts to see Psychic Whispers from xenomorphs.
5. Fixed the 'me' emote system not accepting 'Them' and 'Their'.
6. Disabled the character limit for 'me' emotes.
7. Allowed xenomorphs to 'Devour' living humans.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
QOL improvements.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Allowed xenomorphs to 'Devour' living humans.
qol: Allowed ghosts to see psychic whispers.
qol: Fixed 'Them' and 'Their' being replaced in emotes, and disabled the emote limit.
balance: Made xenomorphs always grabbable by humans.
admin: Adds MOOC and XOOC for admins, since apparently I forgot.
admin: Made the restart vote automatically pass unless stopped by admins, rather than the other way around.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
